### PR TITLE
SubsidiesRegistry: Return no fundId when paused

### DIFF
--- a/contracts/sfc/SubsidiesRegistry.sol
+++ b/contracts/sfc/SubsidiesRegistry.sol
@@ -182,6 +182,9 @@ contract SubsidiesRegistry is ISubsidiesRegistry, OwnableUpgradeable, UUPSUpgrad
         bytes calldata callData,
         uint256 fee
     ) public view returns (bytes32 fundId) {
+        if (paused()) {
+            return bytes32(0);
+        }
         // Check all possible sponsorship funds in order of precedence.
         fundId = accountNonceSponsorshipFundId(from, nonce);
         if (fundId != bytes32(0) && sponsorships[fundId].available >= fee) {

--- a/test/SubsidiesRegistry.ts
+++ b/test/SubsidiesRegistry.ts
@@ -269,6 +269,19 @@ describe('SubsidiesRegistry', () => {
       .withArgs(fundId, this.sponsor, 100);
   });
 
+  it('Enforce pause for chooseFund', async function () {
+    const from = ethers.Wallet.createRandom();
+    const to = ethers.Wallet.createRandom();
+    const expectedFundId = await this.registry.contractSponsorshipFundId(to);
+    await this.registry.sponsor(expectedFundId, { value: 10 });
+    const choosenFundId = await this.registry.chooseFund(from, to, 5, 1, '0x', 5);
+    expect(choosenFundId).to.equal(expectedFundId);
+
+    await this.registry.connect(this.owner).pause();
+    const choosenFundIdPaused = await this.registry.chooseFund(from, to, 5, 1, '0x', 5);
+    expect(choosenFundIdPaused).to.equal(noFundId);
+  });
+
   it('Enforce ownerOnly', async function () {
     const anyAddress = ethers.Wallet.createRandom();
     expect(this.registry.upgradeToAndCall(anyAddress, '0x')).to.be.revertedWithCustomError(


### PR DESCRIPTION
Deployed as:
https://sonicscan.org/address/0xB10a2d5292CD19ad4fC729939d368C032C5a8998
https://testnet.sonicscan.org/address/0xB10a2d5292CD19ad4fC729939d368C032C5a8998
